### PR TITLE
docs: 修复 README 中失效的 Star History 图表

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,4 +244,4 @@ ZASHBOARD_OPENCLASH_CONFIG_DIR
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=liandu2024/AnGe-ClashBoard&type=Date)](https://www.star-history.com/#liandu2024/AnGe-ClashBoard&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=liandu2024/AnGe-ClashBoard&type=Date)](https://star-history.dera.page/#liandu2024/AnGe-ClashBoard&Date)


### PR DESCRIPTION
README 中的 Star History 图表目前因数据源限制已经失效，无法正常展示项目星标历史。本 PR 将图表地址更新到可用的镜像服务，同时保留原有仓库与图表类型参数，修复后图表即可恢复正常显示。